### PR TITLE
`write-tag!` won't write tags to audio files without tags.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject claudio "0.1.3"
+(defproject claudio "0.1.4"
   :description "A simple utility for reading and writing textual ID3 tag data"
   :url "https://github.com/pandeiro/claudio"
   :license {:name "Eclipse Public License"

--- a/src/claudio/id3.clj
+++ b/src/claudio/id3.clj
@@ -22,6 +22,12 @@
     (when-not (empty? v)
       (vector (keywordify k) v))))
 
+(defn- get-or-create-tag [audio-file]
+  (or (.getTag audio-file)
+      (let [tag (.createDefaultTag audio-file)]
+        (.setTag audio-file tag)
+        tag)))
+
 ;;
 ;; API
 ;;
@@ -45,7 +51,7 @@ Returns the updated tag map."
     (when-not (even? (count kvs))
       (throw (Exception. "Tag-value pairs must an even number")))
     (let [audio-file (org.jaudiotagger.audio.AudioFileIO/read f)]
-      (when-let [tag (.getTag audio-file)]
+      (when-let [tag (get-or-create-tag audio-file)]
         (doseq [[k v] (partition 2 kvs)]
           (let [field-key (->constant (or (and (keyword? k) (constantify k)) k))]
             (if v


### PR DESCRIPTION
I've added a function that creates and sets default tag. In jaudiotagger's API docs they have function `getTagOrCreateAndSetDefault()` that does the same, but it is not available in 2.0.3. You might want to update deps instead of merging this patch.
