### PR TITLE
Update to latest JAudioTagger release 2.2.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,7 @@
   :url "https://github.com/pandeiro/claudio"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org/jaudiotagger "2.0.3"]])
+  :repositories {"jaudiotagger-repository"
+                 {:url "https://dl.bintray.com/ijabz/maven"}}
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [net.jthink/jaudiotagger "2.2.5"]])

--- a/src/claudio/id3.clj
+++ b/src/claudio/id3.clj
@@ -45,7 +45,7 @@ Returns the updated tag map."
     (when-not (even? (count kvs))
       (throw (Exception. "Tag-value pairs must an even number")))
     (let [audio-file (org.jaudiotagger.audio.AudioFileIO/read f)]
-      (when-let [tag (.getTag audio-file)]
+      (when-let [tag (.getTagOrCreateAndSetDefault audio-file)]
         (doseq [[k v] (partition 2 kvs)]
           (let [field-key (->constant (or (and (keyword? k) (constantify k)) k))]
             (if v


### PR DESCRIPTION
Also integrated the `getTagOrCreateAndSetDefault` fix from @codeboost.